### PR TITLE
0.7 - Add log framework

### DIFF
--- a/src/ranchbot/core/args.py
+++ b/src/ranchbot/core/args.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import argparse
+
+
+def getArgsParser() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="The ranch Discord bot.")
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="Enable debug messages",
+    )
+    args = parser.parse_args()
+    return args

--- a/src/ranchbot/core/bot.py
+++ b/src/ranchbot/core/bot.py
@@ -7,6 +7,8 @@ from asyncio import AbstractEventLoop
 import discord
 from discord.ext import commands
 
+from util.log import log
+
 
 class Bot(commands.Bot):
 
@@ -14,6 +16,7 @@ class Bot(commands.Bot):
     __COG_FILE_REGEXP = "**/*.py"
 
     __STATUS = ""
+    __LOGGER = log.getLogger(__name__)
 
     def __init__(self, prefix: str, status: str, eventLoop: AbstractEventLoop = None):
         intents = discord.Intents.default()
@@ -49,7 +52,7 @@ class Bot(commands.Bot):
                 pathStr = str.removesuffix(pathStr, ".py")
                 pathStr = str.replace(pathStr, ".", "")
                 pathStr = pathStr[pathStr.find(self.__COGS_BASE_PATH) :]
-                print(pathStr)
+                self.__LOGGER.debug(pathStr)
                 pathStr = str.removeprefix(pathStr, pathSeparator)
                 pathStr = str.removesuffix(pathStr, pathSeparator)
                 pathStr = str.replace(pathStr, pathSeparator, ".")
@@ -59,15 +62,15 @@ class Bot(commands.Bot):
     def loadCommands(self):
         for cog in self.__COGS:
             try:
-                print(f"Loading cog {cog}")
+                self.__LOGGER.info(f"Loading cog {cog}")
                 self.load_extension(cog)
-                print(f"Loaded cog {cog}")
+                self.__LOGGER.info(f"Loaded cog {cog}")
             except Exception as e:
                 exc = "{}: {}".format(type(e).__name__, e)
-                print("Failed to load cog {}\n{}".format(cog, exc))
+                self.__LOGGER.error("Failed to load cog {}\n{}".format(cog, exc))
 
     async def on_ready(self):
-        print("Bot is ready!")
+        self.__LOGGER.info("Bot is ready!")
         await self.change_presence(
             status=discord.Status.online, activity=discord.Game(self.__STATUS)
         )

--- a/src/ranchbot/main.py
+++ b/src/ranchbot/main.py
@@ -1,8 +1,12 @@
 import os
 import sys
+import logging
 
 from dotenv import load_dotenv
+
 from core.bot import Bot
+from core import args
+from util.log import log
 
 load_dotenv()
 
@@ -10,28 +14,35 @@ token = os.environ.get("TOKEN")
 status = os.environ.get("STATUS")
 prefix = os.environ.get("PREFIX")
 
+logger = None
+
 
 def checkConfigValues():
     if token is None or token == "":
-        print(
+        logger.critical(
             "The token could not be retrieved from environment variables. Please set the TOKEN environment variable and try again."
         )
         sys.exit(-1)
 
     if status is None or status == "":
-        print(
+        logger.critical(
             "The activity status could not be retrieved from environment variables. Please set the STATUS environment variable and try again."
         )
         sys.exit(-1)
 
     if prefix is None or prefix == "":
-        print(
+        logger.critical(
             "The command prefix could not be retrieved from environment variables. Please set the PREFIX environment variable and try again."
         )
         sys.exit(-1)
 
 
 if __name__ == "__main__":
+    args = args.getArgsParser()
+    if args.debug:
+        log.setLogLevel(logging.DEBUG)
+    logger = log.getLogger(__name__)
+    logger.debug("Debugging messages are enabled!")
     checkConfigValues()
     bot = Bot(prefix, status)
     bot.loadCommands()

--- a/src/ranchbot/util/log/log.py
+++ b/src/ranchbot/util/log/log.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import logging
+
+loggers = dict()
+logLevel = logging.INFO
+
+
+def setLogLevel(level: int):
+    global logLevel
+    logLevel = level
+
+
+def getLogger(name: str) -> logging.Logger:
+    if name not in loggers.keys():
+        logging.basicConfig(level=logLevel)
+        logger = logging.getLogger(name)
+        logger.setLevel(logLevel)
+        loggers[name] = logger
+
+    return loggers[name]


### PR DESCRIPTION
The changes in this PR adds logging via the built-in "logging" module, as well as support for parsing command line arguments. A command line argument (-d or --debug) has been added to print debug messages, otherwise the least severe level that the logger will print is INFO. The logs are currently only printed to stdout.