### PR TITLE
Version status

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -8,11 +8,14 @@ case $1 in
     if [[ "$OLD_VERSION" == "$OLD_VERSION_PREFIX" ]]
     then
         python3 -m poetry version patch
-        OLD_VERSION=$(python3 -m poetry version -s)
-        OLD_VERSION_PREFIX=${OLD_VERSION%-*}
+        TEMP_VERSION=$(python3 -m poetry version -s)
+        TEMP_VERSION_PREFIX=${TEMP_VERSION%-*}
+        NEW_VERSION="$TEMP_VERSION_PREFIX-$SUFFIX"
+    else
+        NEW_VERSION="$OLD_VERSION_PREFIX-$SUFFIX"
     fi
 
-    python3 -m poetry version "$OLD_VERSION_PREFIX-$SUFFIX"
+    python3 -m poetry version "$NEW_VERSION"
     ;;
     patch)
     if [[ "$OLD_VERSION" != "$OLD_VERSION_PREFIX" ]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -208,7 +208,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "py-cord"
-version = "2.0.0a4843+gb40a4bc5"
+version = "2.0.0a4850+gd2878166"
 description = "A Python wrapper for the Discord API"
 category = "main"
 optional = false
@@ -227,7 +227,7 @@ voice = ["PyNaCl (>=1.3.0,<1.6)"]
 type = "git"
 url = "https://github.com/Pycord-Development/pycord.git"
 reference = "master"
-resolved_reference = "b40a4bc558bd95edf7ae448258cdef5f8aa1e5e4"
+resolved_reference = "d2878166df9bc5c6f9ea86587876d571daab28ec"
 
 [[package]]
 name = "pyparsing"
@@ -332,7 +332,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.11"
-content-hash = "30e886990c01f48cccdc86cc369a93b350f07ea7145492262746a842ec777c8e"
+content-hash = "55c404f06e985388c9be2c76ab2186dac6c6de1288b6e99c4dd35b05617ec273"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ranch-bot"
-version = "0.1.1"
+version = "0.1.2-1642974902"
 description = ""
 authors = ["Erik Wahlberger <ewahlberger@gmail.com>"]
 

--- a/src/ranchbot/core/bot.py
+++ b/src/ranchbot/core/bot.py
@@ -8,6 +8,7 @@ import discord
 from discord.ext import commands
 
 from ranchbot.util.log import log
+import ranchbot.core.version as version
 
 
 class Bot(discord.Bot):
@@ -72,5 +73,5 @@ class Bot(discord.Bot):
     async def on_ready(self):
         self.__LOGGER.info("Bot is ready!")
         await self.change_presence(
-            status=discord.Status.online, activity=discord.Game(self.__STATUS)
+            status=discord.Status.online, activity=discord.Game("version " + version.__version__)
         )

--- a/src/ranchbot/core/version.py
+++ b/src/ranchbot/core/version.py
@@ -7,10 +7,7 @@ def get_version() -> str:
     script_path = os.path.dirname(os.path.realpath(__file__))
     config_path = os.path.join(script_path, "../", "../", "../", CONFIG_NAME)
 
-    print(config_path)
-
     config = toml.load(config_path)
-    print(config)
 
     return config['tool']['poetry']['version']
 

--- a/src/ranchbot/core/version.py
+++ b/src/ranchbot/core/version.py
@@ -1,0 +1,18 @@
+import toml
+import os
+
+CONFIG_NAME = "pyproject.toml"
+
+def get_version() -> str:
+    script_path = os.path.dirname(os.path.realpath(__file__))
+    config_path = os.path.join(script_path, "../", "../", "../", CONFIG_NAME)
+
+    print(config_path)
+
+    config = toml.load(config_path)
+    print(config)
+
+    return config['tool']['poetry']['version']
+
+
+__version__ = get_version()


### PR DESCRIPTION
The changes in this PR change the status message of the Discord bot from a string in the configuration to simply showing the version number of the bot. I feel like this is more useful information right now. It might be changed later to, for example, the output of a command.